### PR TITLE
remove status change

### DIFF
--- a/plugin/zaprite.php
+++ b/plugin/zaprite.php
@@ -307,7 +307,6 @@ function zaprite_server_init()
                         $order->save();
                     }
                     if ( !$order->has_status( 'completed' ) ) {
-                        $order->update_status('processing', 'Order status updated via API.', true);
                         $order->add_order_note('Payment is settled.');
                         $order->payment_complete();
                         $order->save();


### PR DESCRIPTION
The `payment_complete()` function will automatically deal with status changes on the Order.

https://woocommerce.github.io/code-reference/classes/WC-Order.html#method_payment_complete

> Most of the time this should mark an order as 'processing' so that admin can process/post the items. If the cart contains only downloadable items then the order is 'completed' since the admin needs to take no action.

If an _Order_ contains only virtual/downloadable Products, this line was causing the _Order_ status to be reverted back to `Processing`.