### PR TITLE
Add payment info in Woo callback

### DIFF
--- a/zaprite-payment-gateway/changelog.txt
+++ b/zaprite-payment-gateway/changelog.txt
@@ -1,5 +1,9 @@
 Zaprite Payment Gateway
 
+## [1.0.3] - 2024-04-09
+
+- Update: Add payment info in the order metadata.
+
 ## [1.0.2] - 2024-03-27
 
 - Update: Use standard Authorization header.

--- a/zaprite-payment-gateway/readme.txt
+++ b/zaprite-payment-gateway/readme.txt
@@ -4,7 +4,7 @@ Tags: payment, gateway, woocommerce, bitcoin, lightning
 Requires at least: 6.4.0
 Tested up to: 6.4.3
 Requires PHP: 7.2
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: MIT
 License URI: https://mit-license.org/
 
@@ -36,6 +36,9 @@ This plugin integrates seamlessly with your WooCommerce Checkout, providing a fa
 
 == Changelog ==
 
+= 1.0.3 =
+* Update: Add payment info in the order metadata.
+
 = 1.0.2 =
 * Update: Use standard Authorization header.
 
@@ -46,6 +49,9 @@ This plugin integrates seamlessly with your WooCommerce Checkout, providing a fa
 * Initial release: Zaprite payment gateway with Bitcoin, Lightning and card Checkout support.
 
 == Upgrade Notice ==
+
+= 1.0.3 =
+This update adds payment info in the order metadata.
 
 = 1.0.2 =
 This updates add support for standard Authorization headers.

--- a/zaprite-payment-gateway/zaprite-payment-gateway.php
+++ b/zaprite-payment-gateway/zaprite-payment-gateway.php
@@ -4,7 +4,7 @@
  * Plugin Name: Zaprite Payment Gateway
  * Plugin URI: https://github.com/ZapriteApp/zaprite-for-woocommerce
  * Description: Accept bitcoin (on-chain and lightning) and fiat payments in one unified Zaprite Checkout.
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: zaprite
  * Author URI: https://zaprite.com
  * Text Domain: zaprite-payment-gateway

--- a/zaprite-payment-gateway/zaprite-payment-gateway.php
+++ b/zaprite-payment-gateway/zaprite-payment-gateway.php
@@ -322,10 +322,10 @@ function zaprite_server_init() {
 								// Format display as 0.00000001 instead of 1E-7
 								$txnAmountMajorUnits = sprintf( '%.8f', $txnAmountMajorUnits );
 							}
-							$order->add_meta_data( 'zaprite_txn_id_' . $index, $transaction['id'], false );
-							$order->add_meta_data( 'zaprite_txn_amount_' . $index, $txnAmountMajorUnits, false );
-							$order->add_meta_data( 'zaprite_txn_currency_' . $index, $txnCurrency, false );
-							$order->add_meta_data( 'zaprite_txn_plugin_' . $index, $transaction['pluginSlug'], false );
+							$order->add_meta_data( 'zaprite_txn' . $index . '_id', $transaction['id'], false );
+							$order->add_meta_data( 'zaprite_txn' . $index . '_amount', $txnAmountMajorUnits, false );
+							$order->add_meta_data( 'zaprite_txn' . $index . '_currency', $txnCurrency, false );
+							$order->add_meta_data( 'zaprite_txn' . $index . '_plugin', $transaction['pluginSlug'], false );
 							++$index;
 						}
 						$order->save();

--- a/zaprite-payment-gateway/zaprite-payment-gateway.php
+++ b/zaprite-payment-gateway/zaprite-payment-gateway.php
@@ -313,6 +313,21 @@ function zaprite_server_init() {
 						}
 						$order->add_order_note( 'Payment is settled.' );
 						$order->payment_complete();
+						$transactions = $orderStatusRes['response']['transactions'];
+						$index        = 1;
+						foreach ( $transactions as $transaction ) {
+							$txnCurrency         = $transaction['currency'];
+							$txnAmountMajorUnits = Utils::from_smallest_unit( $transaction['amount'], $txnCurrency );
+							if ( $txnCurrency == 'BTC' ) {
+								// Format display as 0.00000001 instead of 1E-7
+								$txnAmountMajorUnits = sprintf( '%.8f', $txnAmountMajorUnits );
+							}
+							$order->add_meta_data( 'zaprite_txn_id_' . $index, $transaction['id'], false );
+							$order->add_meta_data( 'zaprite_txn_amount_' . $index, $txnAmountMajorUnits, false );
+							$order->add_meta_data( 'zaprite_txn_currency_' . $index, $txnCurrency, false );
+							$order->add_meta_data( 'zaprite_txn_plugin_' . $index, $transaction['pluginSlug'], false );
+							++$index;
+						}
 						$order->save();
 					}
 					error_log( 'PAID' );


### PR DESCRIPTION
Add payment plugin: Square, Strike, Bitcoin Wallet, etc.
Add currency: BTC, USD, etc.
Add for each transaction in an order. * An order can have many transactions.

<img width="1217" alt="Screenshot 2024-04-08 at 10 51 00 PM" src="https://github.com/ZapriteApp/zaprite-for-woocommerce/assets/1273575/cb596e6b-41ca-452e-aad7-2061ca0e007b">
