### PR TITLE
Fix Order Number

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,3 +166,6 @@ Dependencies
 4. `npm run build`
 5. If you want to package a zip to upload to wordpress plugin manually run
    `npm run package`
+
+# Updates and Changelog
+If you update the code and add a new feature make sure to increment the version number and add a changelog entry, see: https://github.com/ZapriteApp/zaprite-for-woocommerce/pull/37/files

--- a/zaprite-payment-gateway/changelog.txt
+++ b/zaprite-payment-gateway/changelog.txt
@@ -1,5 +1,9 @@
 Zaprite Payment Gateway
 
+## [1.0.7] - 2025-10-01
+
+- Bug Fix: Fix Order number.
+
 ## [1.0.6] - 2025-08-29
 
 - Update: Bump versions and add pricing link.

--- a/zaprite-payment-gateway/includes/zaprite_api.php
+++ b/zaprite-payment-gateway/includes/zaprite_api.php
@@ -19,9 +19,10 @@ class API {
 
 		error_log( "ZAPRITE: URL $this->api_url" );
 
-		$c     = new CurlWrapper();
-		$order = wc_get_order( $order_id );
-		error_log( "ZAPRITE: amount in smallest unit $amount $currency" );
+		$c            = new CurlWrapper();
+		$order        = wc_get_order( $order_id );
+		$order_number = $order->get_order_number(); // Get sequential order number if plugin is active
+		error_log( "ZAPRITE: amount in smallest unit $amount $currency Order Number: $order_number" );
 		$headers = array(
 			'Content-Type' => 'application/json',
 		);
@@ -39,11 +40,11 @@ class API {
 			'currency'            => $currency,
 			'orderUpdateCallback' => $orderUpdateCallback,
 			'redirectUrl'         => $completelink,
-			'externalOrderId'     => "$order_id",
+			'externalOrderId'     => "$order_number",
 			'externalUniqId'      => $key,
 		);
-		$query_params = array(
-			'wooPluginVersion'    => ZAPRITE_WOOCOMMERCE_VERSION,
+		$query_params        = array(
+			'wooPluginVersion' => ZAPRITE_WOOCOMMERCE_VERSION,
 		);
 		$response            = $c->post( "$this->api_url/api/public/woo/create-order", $query_params, json_encode( $data ), $headers );
 		error_log( 'Send invoice status ===>' . $response['status'] );
@@ -59,15 +60,15 @@ class API {
 		);
 		$zapriteOrderId = $order->get_meta( 'zaprite_order_id', $order_id, true );
 		error_log( "ZAPRITE: checkCharge zapriteOrderId = $zapriteOrderId" );
-		$data     = array(
+		$data         = array(
 			'apiKey'  => $this->api_key,
 			'orderId' => "$zapriteOrderId",
 		);
 		$query_params = array(
-			'wooPluginVersion'    => ZAPRITE_WOOCOMMERCE_VERSION,
+			'wooPluginVersion' => ZAPRITE_WOOCOMMERCE_VERSION,
 		);
-		$apiKey   = $this->api_key;
-		$response = $c->post( "$this->api_url/api/public/woo/check-order", $query_params, json_encode( $data ), $headers );
+		$apiKey       = $this->api_key;
+		$response     = $c->post( "$this->api_url/api/public/woo/check-order", $query_params, json_encode( $data ), $headers );
 		error_log( 'Check order status ===>' . $response['status'] );
 		return $response;
 	}

--- a/zaprite-payment-gateway/readme.txt
+++ b/zaprite-payment-gateway/readme.txt
@@ -4,7 +4,7 @@ Tags: payment, gateway, woocommerce, bitcoin, lightning
 Requires at least: 6.4.0
 Tested up to: 6.8.2
 Requires PHP: 7.2
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: MIT
 License URI: https://mit-license.org/
 
@@ -42,6 +42,9 @@ https://youtu.be/ohepHnGE3Tk?si=LEV1z86-BQOgB3i6
 
 == Changelog ==
 
+= 1.0.7 =
+* Update: Fix order number.
+
 = 1.0.6 =
 * Update: Bump versions and add pricing link.
 
@@ -64,6 +67,9 @@ https://youtu.be/ohepHnGE3Tk?si=LEV1z86-BQOgB3i6
 * Initial release: Zaprite payment gateway with Bitcoin, Lightning and card Checkout support.
 
 == Upgrade Notice ==
+
+= 1.0.7 =
+* Update: Fix order number.
 
 = 1.0.6 =
 Tested for latest version.

--- a/zaprite-payment-gateway/zaprite-payment-gateway.php
+++ b/zaprite-payment-gateway/zaprite-payment-gateway.php
@@ -4,7 +4,7 @@
  * Plugin Name: Zaprite Payment Gateway
  * Plugin URI: https://github.com/ZapriteApp/zaprite-for-woocommerce
  * Description: Accept bitcoin (on-chain and lightning) and fiat payments in one unified Zaprite Checkout.
- * Version: 1.0.6
+ * Version: 1.0.7
  * Author: zaprite
  * Author URI: https://zaprite.com
  * Text Domain: zaprite-payment-gateway
@@ -23,7 +23,7 @@ define(
 );
 
 
-define( 'ZAPRITE_WOOCOMMERCE_VERSION', '1.0.6' );
+define( 'ZAPRITE_WOOCOMMERCE_VERSION', '1.0.7' );
 
 define( 'WC_PAYMENT_GATEWAY_ZAPRITE_FILE', __FILE__ );
 define( 'WC_PAYMENT_GATEWAY_ZAPRITE_URL', plugins_url( '', WC_PAYMENT_GATEWAY_ZAPRITE_FILE ) );


### PR DESCRIPTION
Fix order number reference in Zaprite for users using the  "Sequential Order Number" plugin to generate custom Order numbers in WooCommerce.

This default Order Number is confusing to customers who see it on Zaprite's Checkout, as it differs from what they see when they place the Order on his site.